### PR TITLE
Extract Service Name

### DIFF
--- a/src/function.py
+++ b/src/function.py
@@ -218,6 +218,11 @@ async def _send_log_entry(log_entry, context):
         "log_stream_name": context.log_stream_name,
     }
 
+    service_name = ""
+    if context.log_stream_name.startswith("Framer"):
+        service_name = context.log_stream_name.split("/")[0]
+        context["service_name"] = service_name
+
     session_timeout = _calculate_session_timeout()
 
     async with aiohttp.ClientSession(

--- a/src/function.py
+++ b/src/function.py
@@ -218,10 +218,15 @@ async def _send_log_entry(log_entry, context):
         "log_stream_name": context.log_stream_name,
     }
 
+    # Framer Specific
     service_name = ""
     if context.log_stream_name.startswith("Framer"):
         service_name = context.log_stream_name.split("/")[0]
+        tags = _parse_newrelic_tags()
+        if "account" in tags:
+            service_name = tags["account"].capitalize() + " - " + service_name
         context["service_name"] = service_name
+    # End Framer Specific
 
     session_timeout = _calculate_session_timeout()
 
@@ -320,13 +325,7 @@ def _get_license_key(license_key=None):
     return os.getenv("LICENSE_KEY", "")
 
 
-def _get_newrelic_tags(payload):
-    """
-    This functions gets New Relic's tags from env vars and adds it to the payload
-    A tag is a key value pair. Multiple tags can be specified.
-    Key and value are colon delimited. Multiple key value pairs are semi-colon delimited.
-    e.g. env:prod;team:myTeam
-    """
+def _parse_newrelic_tags():
     nr_tags_str = os.getenv("NR_TAGS", "")
     nr_delimiter = os.getenv("NR_ENV_DELIMITER", ";")
     if nr_tags_str:
@@ -335,7 +334,19 @@ def _get_newrelic_tags(payload):
             for item in nr_tags_str.split(nr_delimiter)
             if not item.startswith(tuple(["aws:", "plugin:"]))
         )
-        payload[0]["common"]["attributes"].update(nr_tags)
+        return nr_tags
+
+
+def _get_newrelic_tags(payload):
+    """
+    This functions gets New Relic's tags from env vars and adds it to the payload
+    A tag is a key value pair. Multiple tags can be specified.
+    Key and value are colon delimited. Multiple key value pairs are semi-colon delimited.
+    e.g. env:prod;team:myTeam
+    """
+    tags = _parse_newrelic_tags()
+    if tags is None:
+        payload[0]["common"]["attributes"].update(tags)
 
 
 def _debug_logging_enabled():


### PR DESCRIPTION
As we see below, the *Service Name* is marked as empty in our logs. However, we do have our service name within our log group. This PR adds that field by extracting the service name from the log group and prefixes it with `Production - ` or `Development - ` based off of the NR_Tags we specify in the lambda function (this part I'm not sure is needed, but for now I've added it)

<img width="579" alt="image" src="https://user-images.githubusercontent.com/573531/154250957-b10d281f-b912-464e-8917-99d4674754a8.png">
